### PR TITLE
🛠 fix <cld-image responsive="fill" /> causing scale crop instead of fill crop

### DIFF
--- a/src/helpers/getResizeTransformation.js
+++ b/src/helpers/getResizeTransformation.js
@@ -14,7 +14,7 @@ export function getResizeTransformation(mode, size, breakpoints) {
     fill: merge(
       getDPRAttr(),
       {
-        crop: "crop"
+        crop: "fill"
       },
       !size
         ? { width: 0, height: 0 }


### PR DESCRIPTION
ad. #13 

responsive=fill sets the image element to be stretched (width AND height) to its parent boundaries
That means that if the image served from cld servers does not comply to size of that element (posted as `w` and `h`) it will appear squished or stretched. This happens sometimes with "scale" cropping, seems like "fill" cropping is the solution.