### PR TITLE
make so components can be a component identifiers

### DIFF
--- a/src/utils/find.js
+++ b/src/utils/find.js
@@ -1,12 +1,10 @@
 export function find(subject, predicate) {
-  let result = null;
   if (!(subject instanceof Array)) {
     throw new Error(`find 1st arg must be Array, is: ${typeof subject}`);
   }
-  subject.forEach(i => {
-    if (!result && predicate(i)) {
-      result = { value: i };
+  for (let i = 0, l = subject.length; i < l; i++) {
+    if (predicate(subject[i])) {
+      return subject[i];
     }
-  });
-  return result ? result.value : undefined;
+  }
 }

--- a/tests/unit/plugin.spec.js
+++ b/tests/unit/plugin.spec.js
@@ -1,5 +1,5 @@
 import { mount, createLocalVue } from "@vue/test-utils";
-import * as Cloudinary from "../../src/plugin";
+import Cloudinary, { CldImage } from "../../src";
 
 describe("CLD plugin", () => {
   it("allows specifying Cloudinary configuration", async () => {
@@ -69,6 +69,27 @@ describe("CLD plugin", () => {
       expect(wrapper2.is("video")).toBe(false);
     });
 
+    it("array should contain cld component(s)", async () => {
+      const localVue = createLocalVue();
+      localVue.use(Cloudinary, { components: [CldImage] });
+
+      const wrapper = mount(
+        {
+          template: `<cld-image cloudName="demo" publicId="face_top" />`
+        },
+        { localVue }
+      );
+      expect(wrapper.is("img")).toBe(true);
+
+      const wrapper2 = mount(
+        {
+          template: `<cld-video cloudName="demo" publicId="face_top" />`
+        },
+        { localVue }
+      );
+      expect(wrapper2.is("video")).toBe(false);
+    });
+
     it("object specifies if component should be installed", async () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: { CldImage: true } });
@@ -90,7 +111,7 @@ describe("CLD plugin", () => {
       expect(wrapper2.is("video")).toBe(false);
     });
 
-    it("object with a string specifies under what name a component should be installed", async () => {
+    it("object with a string specifies under what name a component should be installed OLD: NEW", async () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: { CldImage: "CloudinaryImage" } });
 
@@ -111,9 +132,30 @@ describe("CLD plugin", () => {
       expect(wrapper2.is("img")).toBe(false);
     });
 
-    it("object with a string specifies under what name a component should be installed REVERSE", async () => {
+    it("object with a string specifies under what name a component should be installed NEW: OLD", async () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: { CloudinaryImage: "CldImage" } });
+
+      const wrapper = mount(
+        {
+          template: `<cloudinary-image cloudName="demo" publicId="face_top" />`
+        },
+        { localVue }
+      );
+      expect(wrapper.is("img")).toBe(true);
+
+      const wrapper2 = mount(
+        {
+          template: `<cld-image cloudName="demo" publicId="face_top" />`
+        },
+        { localVue }
+      );
+      expect(wrapper2.is("img")).toBe(false);
+    });
+
+    it("object with a cld component specifies under what name a component should be installed", async () => {
+      const localVue = createLocalVue();
+      localVue.use(Cloudinary, { components: { CloudinaryImage: CldImage } });
 
       const wrapper = mount(
         {


### PR DESCRIPTION
component objects can now be a component identifier
just as well as a string that contains a component name

```jsx
import Cloudinary, { CldImage } from 'cloudinary-vue';

Vue.use(Cloudinary, { components: [CldImage] });
// ...and...
Vue.use(Cloudinary, { components: { CloudinaryImage: CldImage } });
```