### PR TITLE
test: component registration test without warnings

### DIFF
--- a/tests/unit/plugin.spec.js
+++ b/tests/unit/plugin.spec.js
@@ -24,68 +24,31 @@ describe("CLD plugin", () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: [] });
 
-      const wrapper = mount(
-        {
-          template: `<cld-image cloudName="demo" publicId="face_top" />`
-        },
-        { localVue }
-      );
-      expect(wrapper.is("img")).toBe(false);
+      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(false);
     });
 
     it("empty object installs no component", async () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: {} });
 
-      const wrapper = mount(
-        {
-          template: `<cld-image cloudName="demo" publicId="face_top" />`
-        },
-        { localVue }
-      );
-      expect(wrapper.is("img")).toBe(false);
+      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(false);
     });
 
     it("array should contain cld component(s)", async () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: [CldImage] });
 
-      const wrapper = mount(
-        {
-          template: `<cld-image cloudName="demo" publicId="face_top" />`
-        },
-        { localVue }
-      );
-      expect(wrapper.contains("img")).toBe(true);
-
-      const wrapper2 = mount(
-        {
-          template: `<cld-video cloudName="demo" publicId="face_top" />`
-        },
-        { localVue }
-      );
-      expect(wrapper2.is("video")).toBe(false);
+      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(true);
+      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldVideo')).toBe(false);
     });
 
-        it("object with a cld component specifies under what name a component should be installed", async () => {
+    it("object with a cld component specifies under what name a component should be installed", async () => {
+      const componentName = 'CloudinaryImage';
       const localVue = createLocalVue();
-      localVue.use(Cloudinary, { components: { CloudinaryImage: CldImage } });
+      localVue.use(Cloudinary, { components: { [componentName]: CldImage } });
 
-      const wrapper = mount(
-        {
-          template: `<cloudinary-image cloudName="demo" publicId="face_top" />`
-        },
-        { localVue }
-      );
-      expect(wrapper.contains("img")).toBe(true);
-
-      const wrapper2 = mount(
-        {
-          template: `<cld-image cloudName="demo" publicId="face_top" />`
-        },
-        { localVue }
-      );
-      expect(wrapper2.contains("img")).toBe(false);
+      expect(Object.hasOwnProperty.call(localVue.options.components, componentName)).toBe(true);
+      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(false);
     });
   });
 });

--- a/tests/unit/plugin.spec.js
+++ b/tests/unit/plugin.spec.js
@@ -24,22 +24,29 @@ describe("CLD plugin", () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: [] });
 
-      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(false);
+      const isComponentInstalled = Object.hasOwnProperty.call(localVue.options.components, 'CldImage');
+
+      expect(isComponentInstalled).toBe(false);
     });
 
     it("empty object installs no component", async () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: {} });
 
-      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(false);
+      const isComponentInstalled = Object.hasOwnProperty.call(localVue.options.components, 'CldImage');
+
+      expect(isComponentInstalled).toBe(false);
     });
 
     it("array should contain cld component(s)", async () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: [CldImage] });
 
-      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(true);
-      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldVideo')).toBe(false);
+      const isImageComponentInstalled = Object.hasOwnProperty.call(localVue.options.components, 'CldImage');
+      const isVideoComponentInstalled = Object.hasOwnProperty.call(localVue.options.components, 'CldVideo');
+
+      expect(isImageComponentInstalled).toBe(true);
+      expect(isVideoComponentInstalled).toBe(false);
     });
 
     it("object with a cld component specifies under what name a component should be installed", async () => {
@@ -47,8 +54,11 @@ describe("CLD plugin", () => {
       const localVue = createLocalVue();
       localVue.use(Cloudinary, { components: { [componentName]: CldImage } });
 
-      expect(Object.hasOwnProperty.call(localVue.options.components, componentName)).toBe(true);
-      expect(Object.hasOwnProperty.call(localVue.options.components, 'CldImage')).toBe(false);
+      const isNamedComponentInstalled = Object.hasOwnProperty.call(localVue.options.components, componentName);
+      const isImageComponentInstalled = Object.hasOwnProperty.call(localVue.options.components, 'CldImage');
+
+      expect(isNamedComponentInstalled).toBe(true);
+      expect(isImageComponentInstalled).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Greetings.
Thanks for the library!

Currently tests for components registration via plugin options throws a warning when mounting unregistered component

`Unknown custom element: <cld-image>`

In order to perform components registration test, it is not necessary to mount the component. Testing can be done by checking list of available components after plugin registration, which eliminates console warnings.