### PR TITLE
Add yarn serve to use as a local dev environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,17 @@
   "name": "cloudinary-vue",
   "version": "1.1.1",
   "scripts": {
+    "serve": "INTERNAL_DEPS=1 vue-cli-service serve ./playground/main.js",
     "build": "vue-cli-service lint --fix; npm run build:styleguide; npm run build:lib",
     "test": "vue-cli-service test:unit",
     "tdd": "yarn run test --watch --coverage=false",
     "bundlewatch": "bundlewatch --config ./bundlewatch.config.js",
     "lint": "vue-cli-service lint",
     "build:lib": "vue-cli-service build --target lib --name Cloudinary src/index.js && npm run bundlewatch",
-    "build:styleguide": "rm -rf docs/*; node docs-sources/generateDocsLinks.js; vue-cli-service lint --fix; STYLEGUIDE=1 vue-styleguidist build",
+    "build:styleguide": "rm -rf docs/*; node docs-sources/generateDocsLinks.js; vue-cli-service lint --fix; INTERNAL_DEPS=1 vue-styleguidist build",
     "storybook:build": "vue-cli-service storybook:build -c config/storybook",
     "storybook:serve": "vue-cli-service storybook:serve -p 6006 -c config/storybook",
-    "styleguide": "node docs-sources/generateDocsLinks.js; vue-cli-service lint --fix; STYLEGUIDE=1 vue-styleguidist server"
+    "styleguide": "node docs-sources/generateDocsLinks.js; vue-cli-service lint --fix; INTERNAL_DEPS=1 vue-styleguidist server"
   },
   "main": "dist/Cloudinary.umd.js",
   "unpkg": "dist/Cloudinary.umd.min.js",

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,7 +2,7 @@ const nodeExternals = require("webpack-node-externals");
 
 module.exports = {
   configureWebpack: config => {
-    if (process.env.STYLEGUIDE) {
+    if (process.env.INTERNAL_DEPS) {
       return;
     }
     config.externals = [nodeExternals()];


### PR DESCRIPTION
### Brief Summary of Changes
This change adds a local dev environment to the developer working on this project.
run `yarn serve` to start a local dev environment based off of `./playgorund/main.js`

#### What does this PR address?
- [ ] Github issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [X] No

#### Reviewer, Please Note:
This is PR has does not affect end-developers but adds functionality when maintaining and adding features to this project