### PR TITLE
Move Vue to PeerDepdency instead of Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ using code that integrates seamlessly with your existing Vue.js application, and
 This Readme provides basic installation and usage information. For the complete documentation, see the [Vue.js SDK guide](https://cloudinary.com/documentation/vue_integration)_
 
 # 🛠️ Installation 
-## Vue 3.x 
-
-1. install using your favorite package manager (yarn, npm)
-    ```bash
-    npm install cloudinary-vue
-    yarn add cloudinary-vue
-    ```
-   
 ## Vue 2.x
 1. Install using Vue-CLI
     - After you create your application with Vue-CLI, navigate to the created app folder, and install Cloudinary SDK by:
@@ -39,29 +31,6 @@ This Readme provides basic installation and usage information. For the complete 
 
 
 # Setup and configuration 
-## Vue 3.x - Setup and configuration
-1. **A Global setup** - Include CloudinaryVue globally
-    - **Globally as a plugin**:
-        ```javascript
-            import { createApp } from 'vue'; 
-            import App from './App.vue'; // Your app component
-            import Cloudinary, {CldContext, CldImage, CldTransformation, CldVideo} from "cloudinary-vue";
-            const app = createApp(App)
-            
-            app.use(Cloudinary, {
-              configuration: { cloudName: 'demo' }, // your cloud name
-                components: {
-                  CldImage,
-                  CldTransformation
-                }
-            })
-            
-            app.mount('#app');
-        ```
-      **Notes**: By default, if `components` is not passed to the Cloudinary plugin, the plugin will _automatically_ install all available Cloudinary components.
-
-2. **A Local setup** - You can also import the cloudinary components manually in each of your components.
-
 ## Vue 2.x - Setup and configuration
 1. **A Global setup** - Include CloudinaryVue globally
     ```javascript

--- a/package.json
+++ b/package.json
@@ -17,15 +17,18 @@
   "main": "dist/Cloudinary.umd.js",
   "unpkg": "dist/Cloudinary.umd.min.js",
   "dependencies": {
-    "@types/jest": "^25.2.3",
     "cloudinary-core": "^2.10.3",
     "cloudinary-video-player": "^1.1.1",
     "core-js": "2.6.9",
-    "current-script-polyfill": "1.0.0",
-    "jest-html-reporters": "^1.2.1",
-    "vue": "2.6.10"
+    "current-script-polyfill": "1.0.0"
+  },
+  "peerDependencies": {
+    "vue": "^2.0.0"
   },
   "devDependencies": {
+    "vue": "2.6.10",
+    "@types/jest": "^25.2.3",
+    "jest-html-reporters": "^1.2.1",
     "@storybook/addon-actions": "^5.0.0",
     "@storybook/addon-knobs": "^5.0.0",
     "@storybook/addon-links": "^5.0.0",


### PR DESCRIPTION
- Add an accurate devDependency for development
- Add a ^2.0.0 peerDependency
- Remove inaccurate support for Vue3

### Brief Summary of Changes
This PR addresses #101 
Also, during testing, it was discovered that vue3 support is inaccurate, and in fact this library does not work with Vue3,
as such the documentation was adjusted

#### What does this PR address?
- [X] Github issue #101 
- [] Refactoring
- [ ] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No (This was manually tested)


