### PR TITLE
Part3 remove accessibility

### DIFF
--- a/src/cloudinary/helper.js
+++ b/src/cloudinary/helper.js
@@ -1,4 +1,4 @@
-import { A11Y_TRANSFORMS, progressive, PLACEHOLDER_OPTIONS, COMPONENTS, predominantColorTransformPxl } from '../constants';
+import { progressive, PLACEHOLDER_OPTIONS, COMPONENTS, predominantColorTransformPxl } from '../constants';
 
 /**
  * 
@@ -11,30 +11,25 @@ const addProgressive = (enable = false) => {
 
 /**
  * 
- * @param {'darkmode'|'brightmode'|'monochrome'|'colorblind'} type 
- * @returns {Object} transformation effect for a11y support based on type
- */
-const addA11y = (type) => {
-  return A11Y_TRANSFORMS[type] || {}
-}
-
-/**
- * 
  * @param {Object} object contains accessibility, withProgressive, cldTransforms and baseOptions
  * @returns {Object} options for generating delivery URL of a media component 
  */
 export const computeOptions = ({ accessibility, withProgressive, baseOptions = {}, extra = [] }) => {
   const transformation = [...extra]
-  const a11y = addA11y(accessibility)
   const progressive = addProgressive(withProgressive)
 
   transformation.push(progressive)
-  transformation.push(a11y)
 
-  return {
+  const res = {
     ...baseOptions,
-    transformation,
+    transformation
   }
+
+  if (accessibility) {
+    res.accessibility = accessibility
+  }
+
+  return res
 }
 
 /**

--- a/tests/unit/cloudinary/index.spec.js
+++ b/tests/unit/cloudinary/index.spec.js
@@ -8,7 +8,7 @@ describe("computeOptions", () => {
     }
 
     expect(computeOptions(options)).toEqual({
-      transformation: [{ flags: ["progressive"] }, {}],
+      transformation: [{ flags: ["progressive"] }],
     })
   })
 
@@ -16,7 +16,7 @@ describe("computeOptions", () => {
     const options = {}
 
     expect(computeOptions(options)).toEqual({
-      transformation: [{}, {}],
+      transformation: [{}],
     })
   })
 })


### PR DESCRIPTION
### Brief Summary of Changes
- Remove mapping of transformations for accessibility since `cloudinary-vue` already implemented this inside.

#### What does this PR address?
- [ ] Github issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, Please Note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
• Dependence on other PRs
• Reference to other Cloudinary SDKs
• Changes that seem arbitrary without further explanations
-->
