### PR TITLE
Remove automatic DPR settings when responsive is set

### DIFF
--- a/src/helpers/responsiveness.js
+++ b/src/helpers/responsiveness.js
@@ -31,7 +31,6 @@ export function getResizeTransformation(mode, size, originalBP) {
             height: Math.floor(size.height)
           };
       return {
-        ...getDPRAttr(),
         crop: "fill",
         ...computedSize
       };
@@ -39,7 +38,6 @@ export function getResizeTransformation(mode, size, originalBP) {
     case true:
     case "width":
       return {
-        ...getDPRAttr(),
         crop: "scale",
         width: Math.floor(
           breakpoints ? findBreakpoint(breakpoints, size.width) : size.width
@@ -48,7 +46,6 @@ export function getResizeTransformation(mode, size, originalBP) {
 
     case "height":
       return {
-        ...getDPRAttr(),
         crop: "scale",
         height: Math.floor(
           breakpoints ? findBreakpoint(breakpoints, size.height) : size.height
@@ -57,9 +54,4 @@ export function getResizeTransformation(mode, size, originalBP) {
     default:
       return {};
   }
-}
-
-/** Generate DPR transformation if DPR information is available */
-export function getDPRAttr() {
-  return "devicePixelRatio" in window ? { dpr: window.devicePixelRatio } : {};
 }

--- a/tests/unit/Image/img_responsive_boolean.spec.js
+++ b/tests/unit/Image/img_responsive_boolean.spec.js
@@ -21,7 +21,7 @@ describe("CldImage::responsive", () => {
     await Vue.nextTick();
 
     expect(image.attributes("src")).toEqual(
-      `http://res.cloudinary.com/demo/image/upload/c_scale,dpr_1.0,w_100/face_top`
+      `http://res.cloudinary.com/demo/image/upload/c_scale,w_100/face_top`
     );
   });
 

--- a/tests/unit/Image/img_responsive_fill.spec.js
+++ b/tests/unit/Image/img_responsive_fill.spec.js
@@ -20,7 +20,7 @@ describe("CldImage::responsive=fill", async () => {
     await Vue.nextTick();
 
     expect(image.attributes("src")).toEqual(
-      `http://res.cloudinary.com/demo/image/upload/c_fill,dpr_1.0,h_100,w_100/face_top`
+      `http://res.cloudinary.com/demo/image/upload/c_fill,h_100,w_100/face_top`
     );
   });
 });

--- a/tests/unit/Image/img_responsive_flag.spec.js
+++ b/tests/unit/Image/img_responsive_flag.spec.js
@@ -20,7 +20,7 @@ describe("CldImage::responsive", () => {
     await Vue.nextTick();
 
     expect(image.attributes("src")).toEqual(
-      `http://res.cloudinary.com/demo/image/upload/c_scale,dpr_1.0,w_100/face_top`
+      `http://res.cloudinary.com/demo/image/upload/c_scale,w_100/face_top`
     );
   });
 });

--- a/tests/unit/Image/img_responsive_height.spec.js
+++ b/tests/unit/Image/img_responsive_height.spec.js
@@ -19,7 +19,7 @@ describe("CldImage::responsive=height", () => {
     await Vue.nextTick();
 
     expect(image.attributes("src")).toEqual(
-      `http://res.cloudinary.com/demo/image/upload/c_scale,dpr_1.0,h_200/face_top`
+      `http://res.cloudinary.com/demo/image/upload/c_scale,h_200/face_top`
     );
   });
 });

--- a/tests/unit/Image/img_responsive_width.spec.js
+++ b/tests/unit/Image/img_responsive_width.spec.js
@@ -19,7 +19,7 @@ describe("CldImage::responsive=width", () => {
     await Vue.nextTick();
 
     expect(image.attributes("src")).toEqual(
-      `http://res.cloudinary.com/demo/image/upload/c_scale,dpr_1.0,w_100/face_top`
+      `http://res.cloudinary.com/demo/image/upload/c_scale,w_100/face_top`
     );
   });
 });


### PR DESCRIPTION
### Brief Summary of Changes
This PR removes automatic DPR detection when `responsive` is used.
This prevented users from using their own custom DPRs with responsive

#### What does this PR address?
- [ ] Refactoring
- [X] New feature
- [X] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No
