### PR TITLE
Adding "imgClass" prop to the CldImage vue component

### DIFF
--- a/src/components/CldImage/CldImage.vue
+++ b/src/components/CldImage/CldImage.vue
@@ -94,7 +94,7 @@ export default {
       this.imageLoaded = true;
     },
     renderImageOnly(src, hasPlaceholder = false) {
-      const imgClass = `${IMAGE_CLASSES.DEFAULT} ${!this.imageLoaded ? IMAGE_CLASSES.LOADING : IMAGE_CLASSES.LOADED} ${this.imgClass}`
+      const imgClass = `${IMAGE_CLASSES.DEFAULT} ${!this.imageLoaded ? IMAGE_CLASSES.LOADING : IMAGE_CLASSES.LOADED}${this.imgClass ? ` ${this.imgClass}` : ''}`
       const style = {
         ...(this.responsive ? RESPONSIVE_CSS[this.responsive] : {}),
         ...(!this.imageLoaded && hasPlaceholder ? IMAGE_WITH_PLACEHOLDER_CSS[IMAGE_CLASSES.LOADING] : {})


### PR DESCRIPTION
### Brief Summary of Changes
After submitting an issue to the repo (cf. https://github.com/cloudinary/cloudinary-vue/issues/145) , I am submitting this pull request to add the possibility to pass a css class down from the `<cld-image>` component to the generated `<img>` tag.

#### What does this PR address?
- [x] Github issue ( #145 )
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, Please Note:
As of today there is no possible way to style the img tag using css class and the component `<cld-image>` because all css class added to the `<cld-image>` (eg. `<cld-image class="my-css-class">`) will apply to the `<div>` container not the `<img>` tag.
